### PR TITLE
Changed JUPYTERLAB_WORKSPACES_DIR in bin/psconda.sh for cleanliness.

### DIFF
--- a/bin/psconda.sh
+++ b/bin/psconda.sh
@@ -1,4 +1,4 @@
-# Needee by JuoyterLab
+# Needed by JupyterLab
 export JUPYTERLAB_WORKSPACES_DIR=${HOME}/.jupyter/lab/workspaces
 export JUPYTERLAB_SETTINGS_DIR=${HOME}/.jupyter/lab/user-settings
 

--- a/bin/psconda.sh
+++ b/bin/psconda.sh
@@ -1,5 +1,5 @@
 # Needee by JuoyterLab
-export JUPYTERLAB_WORKSPACES_DIR=${HOME}
+export JUPYTERLAB_WORKSPACES_DIR=${HOME}/.jupyter/lab/workspaces
 export JUPYTERLAB_SETTINGS_DIR=${HOME}/.jupyter/lab/user-settings
 
 # needed to avoid file locking crash in mpi splitscan tests


### PR DESCRIPTION
Changed the ```JUPYTERLAB_WORKSPACES_DIR``` from ```${HOME}``` to ```${HOME}/.jupyter/lab/workspaces``` so that the *.jupyterlab-workspace files do not clog up the home directory for users. 8914c80fe40ca88987ecdfdf0720ee57aedf7758

Also fixed a typo in typo in the comment right before the previously mentioned line in the same file. d15ad7d54642db177edfd422c4edb66a8ebccfba